### PR TITLE
Use WebP images for faster load

### DIFF
--- a/About.html
+++ b/About.html
@@ -143,7 +143,10 @@
   </div>
 
   <div class="media">
-      <img class="photo" src="images/meet.png" alt="Colorful mocktail drink" width="200" loading="lazy" decoding="async">
+      <picture>
+        <source type="image/webp" srcset="images/meet.webp" />
+        <img class="photo" src="images/meet.png" alt="Colorful mocktail drink" width="200" loading="lazy" decoding="async" />
+      </picture>
     <span class="blobTL" aria-hidden="true"></span>
     <span class="blobBR" aria-hidden="true"></span>
     <span class="shadow-pad" aria-hidden="true"></span>

--- a/flavors.html
+++ b/flavors.html
@@ -154,7 +154,10 @@
 <section class="grid">
   <!-- Card 1 -->
   <article class="card">
-    <img class="card__img" src="images/mocktail.png" alt="Orange sunrise mocktail" loading="lazy" decoding="async" />
+    <picture>
+      <source type="image/webp" srcset="images/mocktail.webp" />
+      <img class="card__img" src="images/mocktail.png" alt="Orange sunrise mocktail" loading="lazy" decoding="async" />
+    </picture>
     <div class="card__body">
       <span class="badge">Bestseller</span>
       <h3 class="card__title">Citrus Sunrise</h3>
@@ -175,7 +178,10 @@
 
   <!-- Card 2 -->
   <article class="card">
-    <img class="card__img" src="images/strawberrylime.png" alt="Strawberry lime duo" loading="lazy" decoding="async" />
+    <picture>
+      <source type="image/webp" srcset="images/strawberrylime.webp" />
+      <img class="card__img" src="images/strawberrylime.png" alt="Strawberry lime duo" loading="lazy" decoding="async" />
+    </picture>
     <div class="card__body">
       <span class="badge">New</span>
       <h3 class="card__title">Strawberry Lime</h3>
@@ -196,7 +202,10 @@
 
   <!-- Card 3 -->
   <article class="card">
-    <img class="card__img" src="images/mojitotwist.png" alt="Green mojito mocktail" loading="lazy" decoding="async" />
+    <picture>
+      <source type="image/webp" srcset="images/mojitotwist.webp" />
+      <img class="card__img" src="images/mojitotwist.png" alt="Green mojito mocktail" loading="lazy" decoding="async" />
+    </picture>
     <div class="card__body">
       <span class="badge">Cool</span>
       <h3 class="card__title">Mojito Twist</h3>
@@ -217,7 +226,10 @@
 
   <!-- Card 4 -->
   <article class="card">
-    <img class="card__img" src="images/berryblaze.png" alt="Berry mocktail" loading="lazy" decoding="async" />
+    <picture>
+      <source type="image/webp" srcset="images/berryblaze.webp" />
+      <img class="card__img" src="images/berryblaze.png" alt="Berry mocktail" loading="lazy" decoding="async" />
+    </picture>
     <div class="card__body">
       <span class="badge">Sweet</span>
       <h3 class="card__title">Berry Bliss</h3>
@@ -238,7 +250,10 @@
 
   <!-- Card 5 -->
   <article class="card">
-    <img class="card__img" src="images/mangowave.png" alt="Tropical mocktail" loading="lazy" decoding="async" />
+    <picture>
+      <source type="image/webp" srcset="images/mangowave.webp" />
+      <img class="card__img" src="images/mangowave.png" alt="Tropical mocktail" loading="lazy" decoding="async" />
+    </picture>
     <div class="card__body">
       <span class="badge">Tropical</span>
       <h3 class="card__title">Mango Wave</h3>
@@ -259,7 +274,10 @@
 
   <!-- Card 6 -->
   <article class="card">
-    <img class="card__img" src="images/pearfizz.png" alt="Pear fizz mocktail" loading="lazy" decoding="async" />
+    <picture>
+      <source type="image/webp" srcset="images/pearfizz.webp" />
+      <img class="card__img" src="images/pearfizz.png" alt="Pear fizz mocktail" loading="lazy" decoding="async" />
+    </picture>
     <div class="card__body">
       <span class="badge">Light</span>
       <h3 class="card__title">Pear Fizz</h3>

--- a/index.html
+++ b/index.html
@@ -178,7 +178,10 @@
       </div>
 
       <div class="media">
-        <img class="photo" src="images/mocktails.png" alt="Colorful mocktail drink" width="200" loading="lazy" decoding="async">
+        <picture>
+          <source type="image/webp" srcset="images/mocktails.webp" />
+          <img class="photo" src="images/mocktails.png" alt="Colorful mocktail drink" width="200" loading="lazy" decoding="async" />
+        </picture>
         <span class="blob" aria-hidden="true"></span>
         <span class="blob2" aria-hidden="true"></span>
         <span class="shadow-pad" aria-hidden="true"></span>


### PR DESCRIPTION
## Summary
- replace PNG images with WebP using `<picture>` for faster loading

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c519e8808329b5fb4c31fe6de59a