### PR TITLE
Fix floating toggles and clean up cocktails section

### DIFF
--- a/flavors.html
+++ b/flavors.html
@@ -142,7 +142,7 @@
         100%{opacity:0; transform:scale(2.4)}
       }
       .theme-toggle{
-        position:fixed; right:20px; top:20px; z-index:60;
+        position:fixed; right:20px; bottom:20px; z-index:60;
         display:inline-flex; align-items:center; gap:10px;
         padding:10px 14px; border-radius:999px; font-weight:800;
         background:linear-gradient(90deg,#ff6a8c,#ffa55b); color:#fff; text-decoration:none;
@@ -162,7 +162,7 @@
         100%{box-shadow:0 0 0 0 rgba(255,106,140,0),0 0 0 10px rgba(255,106,140,0),0 0 0 22px rgba(255,106,140,0)}
       }
       .booze-pill{
-        position:fixed; right:20px; top:70px; z-index:65;
+        position:fixed; right:20px; bottom:80px; z-index:65;
         display:none; align-items:center; gap:10px;
         padding:8px 12px; border-radius:999px; font-weight:900; font-size:13px;
         background:linear-gradient(90deg,#111827,#334155); color:#fff;

--- a/index.html
+++ b/index.html
@@ -153,6 +153,7 @@
       .popular h2{font-size:32px;margin:0 0 24px;font-weight:800;}
       .popular .mocktails h2{color:var(--pink);}
       .popular .cocktails h2{color:var(--blue);}
+      .popular .note{color:var(--muted);font-size:14px;margin:0 0 24px;}
         .popular-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:24px;margin-bottom:48px;}
         .drink-card{border:1px solid var(--ring);border-radius:20px;overflow:hidden;box-shadow:0 10px 24px rgba(2,8,23,.08);background:var(--card);}
         .drink-card img{width:100%;aspect-ratio:4/3;object-fit:cover;display:block;}
@@ -166,7 +167,7 @@
           100%{opacity:0; transform:scale(2.4)}
         }
         .theme-toggle{
-          position:fixed; right:20px; top:20px; z-index:60;
+          position:fixed; right:20px; bottom:20px; z-index:60;
           display:inline-flex; align-items:center; gap:10px;
           padding:10px 14px; border-radius:999px; font-weight:800;
           background:linear-gradient(90deg,#ff6a8c,#ffa55b); color:#fff; text-decoration:none;
@@ -186,7 +187,7 @@
           100%{box-shadow:0 0 0 0 rgba(255,106,140,0),0 0 0 10px rgba(255,106,140,0),0 0 0 22px rgba(255,106,140,0)}
         }
         .booze-pill{
-          position:fixed; right:20px; top:70px; z-index:65;
+          position:fixed; right:20px; bottom:80px; z-index:65;
           display:none; align-items:center; gap:10px;
           padding:8px 12px; border-radius:999px; font-weight:900; font-size:13px;
           background:linear-gradient(90deg,#111827,#334155); color:#fff;
@@ -254,11 +255,6 @@
         </p>
 
         <a class="cta" href="order.html">Order Now</a>
-
-          <svg viewBox="0 0 24 24" fill="none">
-            <path d="M5 12h14M13 6l6 6-6 6" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-          </svg>
-        </a>
       </div>
 
       <div class="media">
@@ -290,6 +286,7 @@
 
       <div class="cocktails">
         <h2>Popular Cocktails</h2>
+        <p class="note">Cocktails are served only to adults of legal drinking age.</p>
         <div class="popular-grid">
           <div class="drink-card">
             <img src="images/Okavango.webp" alt="Okavango Ripple cocktail" loading="lazy" />


### PR DESCRIPTION
## Summary
- Move theme toggle and cocktails pill to bottom so they don't cover navigation links
- Remove stray arrow from hero CTA
- Clarify cocktails section is adults-only

## Testing
- `npx htmlhint index.html flavors.html`


------
https://chatgpt.com/codex/tasks/task_e_68a64b6613008329b6774f2a5bf267f4