### PR TITLE
Enable checkout for popular drinks on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,12 +154,56 @@
       .popular .mocktails h2{color:var(--pink);}
       .popular .cocktails h2{color:var(--blue);}
       .popular .note{color:var(--muted);font-size:14px;margin:0 0 24px;}
-        .popular-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:24px;margin-bottom:48px;}
-        .drink-card{border:1px solid var(--ring);border-radius:20px;overflow:hidden;box-shadow:0 10px 24px rgba(2,8,23,.08);background:var(--card);}
-        .drink-card img{width:100%;aspect-ratio:4/3;object-fit:cover;display:block;}
-        .drink-card h3{margin:12px;font-size:18px;font-weight:700;}
+.card{
+  background:var(--card);border:1px solid var(--ring);border-radius:20px;overflow:hidden;
+  box-shadow:0 10px 24px rgba(2,8,23,.08);display:flex;flex-direction:column;
+}
+.card__img{width:100%;aspect-ratio:4/3;object-fit:cover;display:block}
+.card__body{padding:18px 18px 16px}
+.card__title{margin:0 0 6px;font-size:20px;font-weight:800;color:var(--ink)}
+.badge{
+  display:inline-block;margin-bottom:10px;padding:6px 10px;border-radius:999px;
+  font-weight:700;font-size:12px;color:#fff;background:linear-gradient(90deg,#ff6a8c,#ffa55b)
+}
+.card__text{margin:0 0 14px;color:#526077;line-height:1.7}
+.card__row{display:flex;align-items:center;justify-content:space-between;gap:10px}
+.price{font-weight:800;color:var(--ink)}
+.btn{
+  display:inline-flex;align-items:center;gap:10px;
+  background:linear-gradient(90deg,#ff6a8c,#ffa55b);
+  color:#fff;text-decoration:none;font-weight:700;font-size:14px;
+  padding:10px 16px;border-radius:999px;
+  box-shadow:0 12px 26px rgba(255,122,122,.28);
+  transition:transform .08s ease, box-shadow .2s ease;
+}
+.btn:hover{transform:translateY(-1px);box-shadow:0 16px 30px rgba(255,122,122,.32)}
+.btn svg{width:14px;height:14px}
+.cart-fab{
+  position:fixed; right:20px; bottom:20px;
+  display:inline-flex; align-items:center; gap:10px;
+  padding:12px 18px; border-radius:999px;
+  background:linear-gradient(90deg,#ff6a8c,#ffa55b);
+  color:#fff; text-decoration:none; font-weight:800;
+  box-shadow:0 14px 28px rgba(255,122,122,.28);
+  transition:transform .08s ease, box-shadow .2s ease;
+  z-index:50;
+}
+.cart-fab:hover{ transform:translateY(-1px); box-shadow:0 18px 34px rgba(255,122,122,.32) }
+.cart-fab .badge{
+  min-width:22px; height:22px; border-radius:999px;
+  display:inline-grid; place-items:center; background:#0f172a; color:#fff; font-size:12px; font-weight:800;
+}
+.cart-fab.disabled{ opacity:.5; pointer-events:none }
+.toast{
+  position:fixed;left:50%;bottom:22px;transform:translateX(-50%);
+  background:#0f172a;color:#fff;padding:10px 14px;border-radius:999px;
+  box-shadow:0 10px 24px rgba(2,8,23,.25);font-weight:700;font-size:14px;
+  opacity:0;pointer-events:none;transition:opacity .2s ease, transform .2s ease;
+}
+.toast.show{opacity:1;transform:translateX(-50%) translateY(-4px)}
 
-        /* theme toggle */
+
+/* theme toggle */
         #themeBurst{position:fixed; inset:0; pointer-events:none; z-index:55; opacity:0; transform:scale(.2)}
         #themeBurst.show{animation:theme-burst .7s ease forwards}
         @keyframes theme-burst{
@@ -256,7 +300,7 @@
           Refreshing, handcrafted mocktails made with love, for students. Perfect for study breaks, celebrations, or just because, nje!
         </p>
 
-        <a class="cta" href="order.html">Order Now</a>
+        <a class="cta" href="flavors.html">Order Now</a>
       </div>
 
       <div class="media">
@@ -272,35 +316,170 @@
 
     <!-- popular drinks -->
     <section class="popular">
-      <div class="mocktails">
-        <h2>Popular Mocktails</h2>
-        <div class="popular-grid">
-          <div class="drink-card">
-            <img src="images/berryblaze.png" alt="Berry Bliss mocktail" loading="lazy" />
-            <h3>Berry Bliss</h3>
-          </div>
-          <div class="drink-card">
-            <img src="images/mangowave.png" alt="Mango Wave mocktail" loading="lazy" />
-            <h3>Mango Wave</h3>
+  <div class="mocktails">
+    <h2>Popular Mocktails</h2>
+    <div class="popular-grid">
+      <article class="card">
+        <picture>
+          <source type="image/webp" srcset="images/berryblaze.webp" />
+          <img class="card__img" src="images/berryblaze.png" alt="Berry mocktail" loading="lazy" decoding="async" />
+        </picture>
+        <div class="card__body">
+          <span class="badge">Sweet</span>
+          <h3 class="card__title">Berry Bliss</h3>
+          <p class="card__text">Mixed berries with a soft fizz</p>
+          <div class="card__row">
+            <span class="price">P33</span>
+            <a class="btn add" href="#"
+               data-name="Berry Bliss"
+               data-price="33"
+               data-note="Mixed berries with a soft fizz"
+               data-emoji="🫐">
+              Add
+              <svg viewBox="0 0 24 24" fill="none"><path d="M5 12h14M13 6l6 6-6 6" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </a>
           </div>
         </div>
-      </div>
+      </article>
 
-      <div class="cocktails">
-        <h2>Popular Cocktails</h2>
-        <p class="note">Cocktails are served only to adults of legal drinking age.</p>
-        <div class="popular-grid">
-          <div class="drink-card">
-            <img src="images/Okavango.webp" alt="Okavango Ripple cocktail" loading="lazy" />
-            <h3>Okavango Ripple</h3>
-          </div>
-          <div class="drink-card">
-            <img src="images/StrawberryD.webp" alt="Strawberry Daiquiri cocktail" loading="lazy" />
-            <h3>Strawberry Daiquiri</h3>
+      <article class="card">
+        <picture>
+          <source type="image/webp" srcset="images/mangowave.webp" />
+          <img class="card__img" src="images/mangowave.png" alt="Tropical mocktail" loading="lazy" decoding="async" />
+        </picture>
+        <div class="card__body">
+          <span class="badge">Tropical</span>
+          <h3 class="card__title">Mango Wave</h3>
+          <p class="card__text">Mango and passion fruit with chill vibes</p>
+          <div class="card__row">
+            <span class="price">P35</span>
+            <a class="btn add" href="#"
+               data-name="Mango Wave"
+               data-price="35"
+               data-note="Mango and passion fruit with chill vibes"
+               data-emoji="🥭">
+              Add
+              <svg viewBox="0 0 24 24" fill="none"><path d="M5 12h14M13 6l6 6-6 6" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </a>
           </div>
         </div>
-      </div>
-    </section>
+      </article>
+    </div>
+  </div>
+
+  <div class="cocktails">
+    <h2>Popular Cocktails</h2>
+    <p class="note">Cocktails are served only to adults of legal drinking age.</p>
+    <div class="popular-grid">
+      <article class="card">
+        <picture>
+          <img class="card__img" src="images/Okavango.webp" alt="Okavango Ripple cocktail" loading="lazy" decoding="async" />
+        </picture>
+        <div class="card__body">
+          <span class="badge">Signature</span>
+          <h3 class="card__title">Okavango Ripple</h3>
+          <p class="card__text">Botanical blend with wild citrus</p>
+          <div class="card__row">
+            <span class="price">P45</span>
+            <a class="btn add" href="#" data-name="Okavango Ripple" data-price="45" data-note="Botanical blend with wild citrus" data-emoji="🍸">
+              Add
+              <svg viewBox="0 0 24 24" fill="none"><path d="M5 12h14M13 6l6 6-6 6" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </a>
+          </div>
+        </div>
+      </article>
+
+      <article class="card">
+        <picture>
+          <img class="card__img" src="images/StrawberryD.webp" alt="Strawberry Daiquiri cocktail" loading="lazy" decoding="async" />
+        </picture>
+        <div class="card__body">
+          <span class="badge">Fruity</span>
+          <h3 class="card__title">Strawberry Daiquiri</h3>
+          <p class="card__text">Classic blend with a sweet kick</p>
+          <div class="card__row">
+            <span class="price">P42</span>
+            <a class="btn add" href="#" data-name="Strawberry Daiquiri" data-price="42" data-note="Classic blend with a sweet kick" data-emoji="🍹">
+              Add
+              <svg viewBox="0 0 24 24" fill="none"><path d="M5 12h14M13 6l6 6-6 6" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </a>
+          </div>
+        </div>
+      </article>
+    </div>
+  </div>
+</section>
+<div id="toast" class="toast" role="status" aria-live="polite">Added to cart</div>
+
+<script>
+  const CART_KEY = 'nm_cart';
+  const getCart  = () => JSON.parse(localStorage.getItem(CART_KEY) || '[]');
+  const setCart  = c  => localStorage.setItem(CART_KEY, JSON.stringify(c));
+
+  function addToCart(item){
+    const cart = getCart();
+    const existing = cart.find(x => x.name === item.name);
+    if(existing){ existing.qty += 1; }
+    else{ cart.push({ ...item, qty: 1 }); }
+    setCart(cart);
+  }
+
+  function flashToast(msg){
+    const t = document.getElementById('toast');
+    t.textContent = msg || 'Added to cart';
+    t.classList.add('show');
+    setTimeout(()=> t.classList.remove('show'), 900);
+  }
+
+  document.querySelectorAll('.add').forEach(btn=>{
+    btn.addEventListener('click', e=>{
+      e.preventDefault();
+      addToCart({
+        name:  btn.dataset.name,
+        price: Number(btn.dataset.price),
+        note:  btn.dataset.note || '',
+        emoji: btn.dataset.emoji || '🥤'
+      });
+      flashToast(`${btn.dataset.name} added`);
+      const old = btn.textContent;
+      btn.textContent = 'Added';
+      setTimeout(()=> btn.textContent = old, 700);
+    });
+  });
+</script>
+<script>
+  function getCartCount(){
+    try{
+      const cart = JSON.parse(localStorage.getItem('nm_cart') || '[]');
+      return cart.reduce((s,it)=> s + Number(it.qty || 1), 0);
+    }catch(e){ return 0; }
+  }
+  function updateFab(){
+    const n = getCartCount();
+    const fab = document.getElementById('cartFab');
+    const badge = document.getElementById('fabCount');
+    if(!fab || !badge) return;
+    badge.textContent = n;
+    if(n > 0){
+      fab.classList.remove('disabled');
+      fab.setAttribute('aria-disabled','false');
+    }else{
+      fab.classList.add('disabled');
+      fab.setAttribute('aria-disabled','true');
+    }
+  }
+
+  document.querySelectorAll('.add').forEach(b=>{
+    b.addEventListener('click', ()=> setTimeout(updateFab, 0));
+  });
+
+  window.addEventListener('storage', e=>{
+    if(e.key === 'nm_cart') updateFab();
+  });
+
+  updateFab();
+</script>
+
 
       <script>
         const THEME_KEY = 'nm_theme';
@@ -367,5 +546,9 @@
         const firstTheme = localStorage.getItem(THEME_KEY) || 'mocktails';
         setTheme(firstTheme);
       </script>
-  </body>
+<a id="cartFab" class="cart-fab disabled" href="order.html" aria-disabled="true">
+  <span class="badge" id="fabCount">0</span>
+  Checkout
+</a>
+</body>
 </html>


### PR DESCRIPTION
## Summary
- show price and add-to-cart buttons for popular drinks on the landing page
- route home page "Order Now" button to flavor selections
- add cart scripts, toast, and floating checkout button to the homepage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a653ce86908329ad8171874c2e5ff3