### PR TITLE
Improve homepage layout and toast placement

### DIFF
--- a/flavors.html
+++ b/flavors.html
@@ -127,7 +127,7 @@
 
     /* tiny toast */
     .toast{
-      position:fixed;left:50%;bottom:22px;transform:translateX(-50%);
+      position:fixed;left:50%;bottom:100px;transform:translateX(-50%);
       background:#0f172a;color:#fff;padding:10px 14px;border-radius:999px;
       box-shadow:0 10px 24px rgba(2,8,23,.25);font-weight:700;font-size:14px;
       opacity:0;pointer-events:none;transition:opacity .2s ease, transform .2s ease;

--- a/index.html
+++ b/index.html
@@ -154,8 +154,13 @@
       .popular .mocktails h2{color:var(--pink);}
       .popular .cocktails h2{color:var(--blue);}
       .popular .note{color:var(--muted);font-size:14px;margin:0 0 24px;}
-.card{
-  background:var(--card);border:1px solid var(--ring);border-radius:20px;overflow:hidden;
+      .popular-grid{
+        display:grid;
+        gap:36px;
+        grid-template-columns:repeat(auto-fit,minmax(260px,1fr));
+      }
+  .card{
+    background:var(--card);border:1px solid var(--ring);border-radius:20px;overflow:hidden;
   box-shadow:0 10px 24px rgba(2,8,23,.08);display:flex;flex-direction:column;
 }
 .card__img{width:100%;aspect-ratio:4/3;object-fit:cover;display:block}
@@ -195,7 +200,7 @@
 }
 .cart-fab.disabled{ opacity:.5; pointer-events:none }
 .toast{
-  position:fixed;left:50%;bottom:22px;transform:translateX(-50%);
+  position:fixed;left:50%;bottom:100px;transform:translateX(-50%);
   background:#0f172a;color:#fff;padding:10px 14px;border-radius:999px;
   box-shadow:0 10px 24px rgba(2,8,23,.25);font-weight:700;font-size:14px;
   opacity:0;pointer-events:none;transition:opacity .2s ease, transform .2s ease;


### PR DESCRIPTION
## Summary
- make popular drink cards responsive across screen sizes
- move toast messages above floating buttons

## Testing
- ⚠️ `npm test` *(no package.json / tests defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a65814e7b48329b0ca4b42d3cc7a6f