### PR TITLE
Remove demo price footer

### DIFF
--- a/flavors.html
+++ b/flavors.html
@@ -486,8 +486,6 @@
   </article>
 </section>
 
-<p class="note wrap">Prices are for demo only</p>
-
 <!-- tiny toast -->
 <div id="toast" class="toast" role="status" aria-live="polite">Added to cart</div>
 


### PR DESCRIPTION
## Summary
- remove "Prices are for demo only" notice from the flavors page

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a663220da48329b7cf0cfcee51236a